### PR TITLE
Update Default.sublime-keymap

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,6 +1,6 @@
 [
-    {
-        "keys": ["ctrl+n"],
-        "command": "fm_create"
-    }
+//     {
+//         "keys": ["ctrl+n"],
+//         "command": "fm_create"
+//     }
 ]


### PR DESCRIPTION
ctrl+n is used for jumping line in linux/osx env, it would be better to allow users to choose the shortcut key.