### PR TITLE
Enhancement: Retarget view after move

### DIFF
--- a/FMcommands/move.py
+++ b/FMcommands/move.py
@@ -40,8 +40,6 @@ class FmMoveCommand(AppCommand):
         for origin in self.origins:
             view = self.window.find_open_file(origin)
             new_name = os.path.join(path, os.path.basename(origin))
-            if view:
-                close_view(view)
             try:
                 os.rename(origin, new_name)
             except Exception as e:
@@ -50,5 +48,6 @@ class FmMoveCommand(AppCommand):
                 raise OSError('An error occured while moving the file {0!r} '
                               'to {1!r}'.format(origin, new_name))
             if view:
-                self.window.open_file(new_name)
+                view.retarget(new_name)
+
         refresh_sidebar(self.settings, self.window)

--- a/FMcommands/rename.py
+++ b/FMcommands/rename.py
@@ -38,9 +38,7 @@ class FmRenameCommand(AppCommand):
             os.rename(self.origin, dst)
             view = self.window.find_open_file(self.origin)
             if view:
-                close_view(view)
-            if os.path.isfile(dst):
-                self.window.open_file(dst)
+                view.retarget(dst)
 
 
         if os.path.exists(dst):


### PR DESCRIPTION
Calling `view.retarget()` rather than closing and reopening avoids flicker effects and improves user experience.