### PR TITLE
Exclude docs/ directory from .sublime-package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/ export-ignore


### PR DESCRIPTION
The currectly `FileManager.sublime-package` is ~960KB. The `docs/` directory may be not useful at local imho. By removing it from the package, `FileManager.sublime-package` reduces to ~34KB.