### PR TITLE
Remove obsolete imports

### DIFF
--- a/FileManager.py
+++ b/FileManager.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-import os
 import sys
 
 import sublime

--- a/commands/create.py
+++ b/commands/create.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-import os.path
 from ..libs.input_for_path import InputForPath
 from ..libs.sublimefunctions import *
 from .appcommand import AppCommand

--- a/commands/editto.py
+++ b/commands/editto.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-
 from ..libs.sublimefunctions import *
 from .appcommand import AppCommand
 

--- a/commands/find_in_files.py
+++ b/commands/find_in_files.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-
 from ..libs.sublimefunctions import *
 from .appcommand import AppCommand
 

--- a/commands/move.py
+++ b/commands/move.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-
 from ..libs.input_for_path import InputForPath
 from ..libs.sublimefunctions import *
 from .appcommand import AppCommand

--- a/commands/open_all.py
+++ b/commands/open_all.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-
 from ..libs.sublimefunctions import *
 from .appcommand import AppCommand
 

--- a/commands/open_in_browser.py
+++ b/commands/open_in_browser.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-
 from ..libs.sublimefunctions import *
 from .appcommand import AppCommand
 

--- a/commands/open_in_explorer.py
+++ b/commands/open_in_explorer.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-
 from ..libs.sublimefunctions import *
 from .appcommand import AppCommand
 

--- a/commands/open_terminal.py
+++ b/commands/open_terminal.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-
 import subprocess
 from ..libs.sublimefunctions import *
 from .appcommand import AppCommand

--- a/libs/sublimefunctions.py
+++ b/libs/sublimefunctions.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import sublime
 


### PR DESCRIPTION
Looks like `from ..libs.sublimefunctions import *` implicitly imports its imported modules as well. Hence `import os.path` in create.py can be removed.

Furthermore remove the empty line between the `coding utf8` line and the first import in some files to gain consistent look of sources.