### PR TITLE
Fix FmDelete command

### DIFF
--- a/commands/delete.py
+++ b/commands/delete.py
@@ -5,40 +5,16 @@ from .appcommand import AppCommand
 
 
 class FmDeleteCommand(AppCommand):
-    def delete(self, index):
-        if index == 0:
-            for path in self.paths:
-                view = self.window.find_open_file(path)
-                if view is not None:
-                    close_view(view)
-                try:
-                    send2trash(path)
-                except OSError as e:
-                    sublime.error_message("Unable to send to trash: {}".format(e))
-                    raise OSError("Unable to send {0!r} to trash: {1}".format(path, e))
-        if index > 1:
-            view = self.window.find_open_file(self.paths[index - 2])
-            if view is not None:
-                close_view(view)
-
-            # We substract two, because 0, 1 are populated by Confirm, Cancel
-            self.paths.remove(self.paths[index - 2])
-
-            if self.paths:
-                refresh_sidebar(self.settings, self.window)
-                self.run(self.paths)
-
-        refresh_sidebar(self.settings, self.window)
-
     def run(self, paths=None, *args, **kwargs):
         self.settings = get_settings()
         self.window = get_window()
         self.view = get_view()
 
         self.paths = paths or [self.view.file_name()]
-        if get_settings().get("ask_for_confirmation_on_delete") is not False:
-            nitems = "{0} ".format(len(self.paths)) if len(self.paths) > 1 else ""
-            extras = "s" if len(self.paths) > 1 else ""
+        if get_settings().get("ask_for_confirmation_on_delete"):
+            num_paths = len(self.paths)
+            nitems = "{0} ".format(num_paths) if num_paths > 1 else ""
+            extras = "s" if num_paths > 1 else ""
 
             confirm_title = "Confirm"
             confirm_subtitle = "Send {}item{} to trash".format(nitems, extras)
@@ -48,14 +24,31 @@ class FmDeleteCommand(AppCommand):
             paths_to_display = [
                 [confirm_title, confirm_subtitle],
                 [cancel_title, cancel_subtitle],
-            ]
-            for path in self.paths:
-                paths_to_display.append([os.path.basename(path), path])
+            ] + [[os.path.basename(path), path] for path in self.paths]
 
-            self.window.show_quick_panel(
-                paths_to_display, self.delete,
-            )
+            self.window.show_quick_panel(paths_to_display, self.delete)
+
         else:
             # index 0 is like clicking on the first option of the panel
             # ie. confirming the deletion
             self.delete(index=0)
+
+    def delete(self, index):
+        if index == 0:
+            for path in self.paths:
+                view = self.window.find_open_file(path)
+                if view is not None:
+                    close_view(view)
+
+                try:
+                    send2trash(path)
+                except OSError as e:
+                    sublime.error_message("Unable to send to trash: {}".format(e))
+                    raise OSError("Unable to send {0!r} to trash: {1}".format(path, e))
+
+            refresh_sidebar(self.settings, self.window)
+
+        elif index > 1:
+            self.paths.pop(index - 2)
+            if self.paths:
+                self.run(self.paths)

--- a/commands/delete.py
+++ b/commands/delete.py
@@ -12,19 +12,21 @@ class FmDeleteCommand(AppCommand):
 
         self.paths = paths or [self.view.file_name()]
         if get_settings().get("ask_for_confirmation_on_delete"):
-            num_paths = len(self.paths)
-            nitems = "{0} ".format(num_paths) if num_paths > 1 else ""
-            extras = "s" if num_paths > 1 else ""
-
-            confirm_title = "Confirm"
-            confirm_subtitle = "Send {}item{} to trash".format(nitems, extras)
-            cancel_title = "Cancel All (Select an individual item to remove it from the deletion list)"
-            cancel_subtitle = "Cancel deletion of {}item{}".format(nitems, extras)
-
             paths_to_display = [
-                [confirm_title, confirm_subtitle],
-                [cancel_title, cancel_subtitle],
-            ] + [[os.path.basename(path), path] for path in self.paths]
+                [
+                    "Confirm",
+                    "Send {0} items to trash".format(len(self.paths))
+                    if len(self.paths) > 1
+                    else "Send item to trash",
+                ],
+                [
+                    "Cancel All",
+                    "Select an individual item to remove it from the deletion list",
+                ],
+            ]
+            paths_to_display.extend(
+                [os.path.basename(path), path] for path in self.paths
+            )
 
             self.window.show_quick_panel(paths_to_display, self.delete)
 


### PR DESCRIPTION
Commit 5f1b64c8d7eee6163b78d4b4f014b7a461a5e7a9 intends to enable us to individually select files to delete from the quick panel.

1. The following changes are made to the new functionality:

   a) Don't close a related view, as the file won't be deleted, if removed from the quick panel.
   b) Don't refresh the sidebar folder as nothing is changed, if a file is removed from the quick panel.
      (Also avoids refreshing the sidbear twice)

2. Ensures the public `run()` to be the first method in the class.
3. Avoids calling `len(self.path)` multiple times.
4. Use list arithmetic to create the quick panel items.