### PR TITLE
Close all deleted file's views without saving

### DIFF
--- a/commands/delete.py
+++ b/commands/delete.py
@@ -38,9 +38,11 @@ class FmDeleteCommand(AppCommand):
     def delete(self, index):
         if index == 0:
             for path in self.paths:
-                view = self.window.find_open_file(path)
-                if view is not None:
-                    close_view(view)
+                for window in sublime.windows():
+                    view = window.find_open_file(path)
+                    while view is not None:
+                        close_view(view, dont_prompt_save=True)
+                        view = window.find_open_file(path)
 
                 try:
                     send2trash(path)

--- a/libs/sublimefunctions.py
+++ b/libs/sublimefunctions.py
@@ -136,7 +136,9 @@ def yes_no_cancel_panel(
     window.show_quick_panel(items, on_done, 0, 1)
 
 
-def close_view(view_to_close):
+def close_view(view_to_close, dont_prompt_save=False):
+    if dont_prompt_save:
+        view_to_close.set_scratch(True)
     if isST3():
         view_to_close.close()
         return


### PR DESCRIPTION
This PR introduces changes to make sure to close all existing views of the file being deleted in all open windows without prompting to save changes.