### PR TITLE
fix: duplicated file may has different line endings

### DIFF
--- a/commands/create_from_selection.py
+++ b/commands/create_from_selection.py
@@ -43,7 +43,7 @@ class FmCreateFileFromSelectionCommand(sublime_plugin.TextCommand):
 
     def get_path(self, event, for_context_menu=False):
         """
-            @return (base_path: str, relative_path: str)
+        @return (base_path: str, relative_path: str)
         """
         file_name = None
         region = self.view.sel()[0]

--- a/commands/duplicate.py
+++ b/commands/duplicate.py
@@ -42,7 +42,7 @@ class FmDuplicateCommand(AppCommand):
     def duplicate(self, dst, input_path):
         user_friendly_path = user_friendly(dst)
 
-        if  os.path.abspath(self.origin) == os.path.abspath(dst):
+        if os.path.abspath(self.origin) == os.path.abspath(dst):
             sublime.error_message("Destination is the same with the source.")
             return
 

--- a/commands/duplicate.py
+++ b/commands/duplicate.py
@@ -42,6 +42,10 @@ class FmDuplicateCommand(AppCommand):
     def duplicate(self, dst, input_path):
         user_friendly_path = user_friendly(dst)
 
+        if  os.path.abspath(self.origin) == os.path.abspath(dst):
+            sublime.error_message("Destination is the same with the source.")
+            return
+
         if os.path.isdir(self.origin):
             if not os.path.exists(dst):
                 shutil.copytree(self.origin, dst)

--- a/commands/duplicate.py
+++ b/commands/duplicate.py
@@ -53,9 +53,7 @@ class FmDuplicateCommand(AppCommand):
                 )
         else:
             if not os.path.exists(dst):
-                with open(dst, "w") as fp:
-                    with open(self.origin, "r") as fpread:
-                        fp.write(fpread.read())
+                shutil.copy2(self.origin, dst)
                 self.window.open_file(dst)
             else:
 
@@ -68,9 +66,7 @@ class FmDuplicateCommand(AppCommand):
                             "Unable to send to the trash the item {0}".format(e)
                         )
 
-                    with open(dst, "w") as fp:
-                        with open(self.origin, "r") as fpread:
-                            fp.write(fpread.read())
+                    shutil.copy2(self.origin, dst)
                     self.window.open_file(dst)
 
                 def open_file():


### PR DESCRIPTION
[fix: duplicated file may has different line endings](https://github.com/math2001/FileManager/pull/77/commits/e5c83836ac62e3f06c4ef80d220454a5cf0ec260) 

Python's IO stream writing uses OS's line ending. So if you duplicate a Unix line ending file on Windows by writing file
content, the duplicate file will use `\r\n` as its line ending. Why we don't use copy file API at the first place?

---

[fix: disallow duplicate file with dst = src](https://github.com/math2001/FileManager/pull/77/commits/f30c150a7505b172b97d96fe8135f0afcffd5d98) 

It just can't be done. Even worse, if the user select "overwrite", the source file gets deleted first, and no destination file will be created because no source file can be opened anymore.