### PR TITLE
Fix "fm_open_in_explorer" in sidebar causes an exception

### DIFF
--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -79,19 +79,19 @@
     },
     {
         "caption": "Open in Explorer",
-        "platform": "!OSX",
         "command": "fm_open_in_explorer",
         "mnemonic": "O",
         "args": {
+            "visible_on_platforms": ["windows", "linux"],
             "paths": []
         }
     },
     {
         "caption": "Open in Finder",
-        "platform": "OSX",
         "command": "fm_open_in_explorer",
         "mnemonic": "O",
         "args": {
+            "visible_on_platforms": ["osx"],
             "paths": []
         }
     },

--- a/commands/open_in_explorer.py
+++ b/commands/open_in_explorer.py
@@ -4,7 +4,7 @@ from .appcommand import AppCommand
 
 
 class FmOpenInExplorerCommand(AppCommand):
-    def run(self, visible_on_platforms, paths=None):
+    def run(self, visible_on_platforms=None, paths=None):
         # visible_on_platforms is just used by is_visible
         self.window = get_window()
         self.view = get_view()
@@ -21,5 +21,5 @@ class FmOpenInExplorerCommand(AppCommand):
                     {"dir": os.path.dirname(path), "file": os.path.basename(path)},
                 )
 
-    def is_visible(self, visible_on_platforms, paths=None):
-        return sublime.platform() in visible_on_platforms and super().is_visible()
+    def is_visible(self, visible_on_platforms=None, paths=None):
+        return super().is_visible() and (visible_on_platforms is None or sublime.platform() in visible_on_platforms)


### PR DESCRIPTION
In https://github.com/math2001/FileManager/commit/74be57b270e12821d9b3dee9f8af4127d765880e, `visible_on_platforms` should be a optional arg.

```py
Traceback (most recent call last):
  File "D:\_Download\ST-SM\sublime_text_build_4129_x64\Lib\python38\sublime_plugin.py", line 1380, in is_visible_
    ret = self.is_visible()
TypeError: is_visible() missing 1 required positional argument: 'visible_on_platforms'
```
