### PR TITLE
Added support for creating PHP files with auto namespace discovery

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,6 +1,6 @@
 [
     {
-        "keys": ["alt+n"],
+        "keys": ["super+n"],
         "command": "fm_create",
         "context": [
             { "key": "package_setting.FileManager.create_keybinding_enabled" }

--- a/FileManager.py
+++ b/FileManager.py
@@ -17,6 +17,7 @@ prefix = None
 from .libs.sublimefunctions import *
 from .commands.copy import FmCopyCommand
 from .commands.create import FmCreaterCommand, FmCreateCommand
+from .commands.create_php_class import FmCreaterPhpClassCommand, FmCreatePhpClassCommand
 from .commands.create_from_selection import FmCreateFileFromSelectionCommand
 from .commands.delete import FmDeleteCommand
 from .commands.duplicate import FmDuplicateCommand

--- a/FileManager.sublime-commands
+++ b/FileManager.sublime-commands
@@ -4,6 +4,30 @@
         "command": "fm_create"
     },
     {
+        "caption": "File Manager: New PHP Class",
+        "command": "fm_create_php_class",
+        "args": {
+            "type": "class",
+            "paths": []
+        }
+    },
+    {
+        "caption": "File Manager: New PHP Interface",
+        "command": "fm_create_php_class",
+        "args": {
+            "type": "interface",
+            "paths": []
+        }
+    },
+    {
+        "caption": "File Manager: New PHP Trait",
+        "command": "fm_create_php_class",
+        "args": {
+            "type": "trait",
+            "paths": []
+        }
+    },
+    {
         "caption": "File Manager: Move",
         "command": "fm_move"
     },

--- a/FileManager.sublime-settings
+++ b/FileManager.sublime-settings
@@ -97,6 +97,7 @@
     // on the other ones.
 
     "show_create_command": true,
+    "show_create_php_class_command": true,
     "show_copy_command": true,
     "show_delete_command": true,
     "show_duplicate_command": true,

--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -8,6 +8,37 @@
         }
     },
     {
+        "caption": "New PHP...",
+        "mnemonic": "p",
+        "children": [
+            {
+                "caption": "Class...",
+                "command": "fm_create_php_class",
+                "mnemonic": "C",
+                "args": {
+                    "type": "class",
+                    "paths": []
+                }
+            }, {
+                "caption": "Interface...",
+                "command": "fm_create_php_class",
+                "mnemonic": "I",
+                "args": {
+                    "type": "interface",
+                    "paths": []
+                }
+            }, {
+                "caption": "Trait...",
+                "command": "fm_create_php_class",
+                "mnemonic": "T",
+                "args": {
+                    "type": "trait",
+                    "paths": []
+                }
+            },
+        ]
+    },
+    {
         "caption": "Open All",
         "command": "fm_open_all",
         "mnemonic": "A",

--- a/commands/create.py
+++ b/commands/create.py
@@ -10,7 +10,7 @@ class FmCreaterCommand(AppCommand):
 
     def run(self, abspath, input_path):
         input_path = user_friendly(input_path)
-        if input_path[-1] == "/":
+        if input_path[-1] == "/" or input_path[1] == "/" or not re.search(r"\.[A-z]+$",input_path):
             return makedirs(abspath, exist_ok=True)
         if not os.path.isfile(abspath):
             makedirs(os.path.dirname(abspath), exist_ok=True)

--- a/commands/create.py
+++ b/commands/create.py
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+import re
 from ..libs.input_for_path import InputForPath
 from ..libs.sublimefunctions import *
 from .appcommand import AppCommand
@@ -73,6 +74,7 @@ class FmCreateCommand(AppCommand):
 
         self.input = InputForPath(
             caption="New: ",
+            type="",
             initial_text=initial_text,
             on_done=self.on_done,
             on_change=self.on_change,
@@ -107,7 +109,7 @@ class FmCreateCommand(AppCommand):
     def is_enabled(self, paths=None):
         return paths is None or len(paths) == 1
 
-    def on_done(self, abspath, input_path):
+    def on_done(self, abspath, input_path, type=""):
         sublime.run_command(
             "fm_creater", {"abspath": abspath, "input_path": input_path}
         )

--- a/commands/create_php_class.py
+++ b/commands/create_php_class.py
@@ -90,10 +90,10 @@ class FmCreaterPhpClassCommand(AppCommand):
             return
 
         # define namespace
-        namespace = "\nnamespace " + namespace if namespace != False else ""
+        namespace = "\nnamespace " + namespace + ";\n" if namespace != False else ""
 
         # define class file content
-        classFileContent = f"<?php\n\ndeclare(strict_types=1);\n{namespace};\n\n{type} {className}\n{{\n}}"
+        classFileContent = f"<?php\n\ndeclare(strict_types=1);\n{namespace}\n{type} {className}\n{{\n}}"
 
         # create file
         with open(abspath, "w") as f:

--- a/commands/create_php_class.py
+++ b/commands/create_php_class.py
@@ -1,0 +1,192 @@
+# -*- encoding: utf-8 -*-
+import re
+import json
+from ..libs.input_for_path import InputForPath
+from ..libs.sublimefunctions import *
+from .appcommand import AppCommand
+
+def getComposerJson(path):
+    # add slash to path
+    path = path.replace(r"\/$", "") + "/"
+
+    try:
+        return json.load(open(path + "composer.json", "r"))
+    except Exception as e:
+        return False
+
+def getNamespaceByFolder(namespaces, folder, path):
+
+    # check if namespaces is type of `dict`
+    if type(namespaces) is not dict:
+        return False
+
+    # remove filename from path
+    # remove folder path from path
+    #
+    # keep path from folder where file will be created
+    path = re.sub(r'\/[A-z_\-0-9]+\.php$', "", path.replace(folder, ""))
+
+    # loop trough all namespaces
+    for key in namespaces:
+        # get namespace path
+        value = [namespaces[key]][0]
+
+        # check if path starts with namespace path
+        if path.startswith("/" + value):
+            # return namespace
+            return key + re.sub(r"^\\", "", path.replace(value, "").replace("/", "\\"))
+
+    return False
+
+class FmCreaterPhpClassCommand(AppCommand):
+
+    """Create PHP class"""
+    def run(self, abspath, className, type):
+        # clear abspath
+        abspath = abspath.replace(".php", "") + ".php"
+
+        # get class name
+        className = toCamelCase(user_friendly(className))
+
+        # make sure that input has `.php` extension
+        className = className.replace(".php", "")
+
+        folders = get_window().folders()
+
+        # define namespace
+        namespace = "PLACEHOLDER_NAMESPACE"
+
+        # loop trough all folders
+        for folder in folders:
+            # when file will be made inside this folder
+            if folder in abspath:
+                # get composer json
+                data = getComposerJson(folder)
+
+                # when there was no composer.json found
+                if data == False:
+                    continue
+
+                try:
+                    # check if is inside unit/feature tests folder
+                    if '/test/' in abspath.replace(folder, "").lower() or '/tests/' in abspath.replace(folder, "").lower():
+                        namespaces = data['autoload-dev']['psr-4']
+                    else:
+                        namespaces = data['autoload']['psr-4']
+
+                    # get namespace from `composer.json`
+                    namespace = getNamespaceByFolder(namespaces, folder, abspath)
+                except Exception as e:
+                    continue
+
+        # check if file(class) already exists
+        if os.path.isfile(abspath):
+            sublime.error_message(f"Class {className} already exists!")
+            return
+
+        # check if classname contains seperator
+        if os.sep in className:
+            sublime.error_message("You can't have {os.sep} inside class name")
+            return
+
+        # define namespace
+        namespace = namespace if namespace != False else "PLACEHOLDER_NAMESPACE"
+
+        # define class file content
+        classFileContent = f"<?php\n\ndeclare(strict_types=1);\n\nnamespace {namespace};\n\n{type} {className}\n{{\n}}"
+
+        # create file
+        with open(abspath, "w") as f:
+            # write base class structure to file
+            f.write(classFileContent)
+
+        f.close()
+
+        # open file inside window
+        view = get_window().open_file(abspath)
+
+        # set default extension
+        view.settings().set('default_extension', 'php')
+
+
+class FmCreatePhpClassCommand(AppCommand):
+    def run(
+        self,
+        type,
+        paths=None,
+        initial_text="",
+        start_with_browser=False,
+        no_browser_action=False
+    ):
+        self.settings = get_settings()
+        self.window = sublime.active_window()
+        self.index_folder_separator = self.settings.get("index_folder_" + "separator")
+        self.default_index = self.settings.get("default_index")
+
+        self.folders = self.window.folders()
+
+        self.view = get_view()
+
+        self.know_where_to_create_from = paths is not None
+
+        if paths is not None:
+            # creating from the sidebar
+            create_from = paths[0].replace("${packages}", sublime.packages_path())
+
+            create_from = transform_aliases(self.window, create_from)
+
+            # you can right-click on a file, and run `New...`
+            if os.path.isfile(create_from):
+                create_from = os.path.dirname(create_from)
+        elif self.folders:
+            # it is going to be interactive, so it'll be
+            # understood from the input itself
+            create_from = None
+        elif self.view.file_name() is not None:
+            create_from = os.path.dirname(self.view.file_name())
+            self.know_where_to_create_from = True
+        else:
+            # from home
+            create_from = "~"
+
+        self.input = InputForPath(
+            caption=f"New PHP {type}: ",
+            type=type,
+            initial_text=initial_text,
+            on_done=self.on_done,
+            on_change=self.on_change,
+            on_cancel=None,
+            create_from=create_from,
+            with_files=self.settings.get("complete_with_files_too"),
+            pick_first=self.settings.get("pick_first"),
+            case_sensitive=self.settings.get("case_sensitive"),
+            log_in_status_bar=self.settings.get("log_in_status_bar"),
+            log_template="Creating at {0}",
+            start_with_browser=start_with_browser,
+            no_browser_action=no_browser_action,
+        )
+
+    def on_change(self, input_path, path_to_create_choosed_from_browsing):
+        if path_to_create_choosed_from_browsing:
+            # The user has browsed, we let InputForPath select the path
+            return
+        if self.know_where_to_create_from:
+            return
+        elif self.folders:
+            splited_input = input_path.split(self.index_folder_separator, 1)
+            if len(splited_input) == 1:
+                index = self.default_index
+            elif isdigit(splited_input[0]):
+                index = int(splited_input[0])
+            else:
+                return None, input_path
+            return self.folders[index], splited_input[-1]
+        return "~", input_path
+
+    def is_enabled(self, paths=None):
+        return paths is None or len(paths) == 1
+
+    def on_done(self, abspath, input_path, type):
+        sublime.run_command(
+            "fm_creater_php_class", {"abspath": abspath, "className": input_path, "type": type}
+        )

--- a/commands/create_php_class.py
+++ b/commands/create_php_class.py
@@ -54,7 +54,7 @@ class FmCreaterPhpClassCommand(AppCommand):
         folders = get_window().folders()
 
         # define namespace
-        namespace = "PLACEHOLDER_NAMESPACE"
+        namespace = False
 
         # loop trough all folders
         for folder in folders:
@@ -90,10 +90,10 @@ class FmCreaterPhpClassCommand(AppCommand):
             return
 
         # define namespace
-        namespace = namespace if namespace != False else "PLACEHOLDER_NAMESPACE"
+        namespace = "\nnamespace " + namespace if namespace != False else ""
 
         # define class file content
-        classFileContent = f"<?php\n\ndeclare(strict_types=1);\n\nnamespace {namespace};\n\n{type} {className}\n{{\n}}"
+        classFileContent = f"<?php\n\ndeclare(strict_types=1);\n{namespace};\n\n{type} {className}\n{{\n}}"
 
         # create file
         with open(abspath, "w") as f:

--- a/libs/input_for_path.py
+++ b/libs/input_for_path.py
@@ -241,7 +241,7 @@ class InputForPath(object):
                     os.path.join(self.create_from, computer_friendly(self.input_path))
                 )
             )
-            if self.input_path != "" and self.input_path[-1] == "/":
+            if self.input_path != "" and (self.input_path[-1] == "/" or self.input_path[0] == "/"):
                 path += os.path.sep
             if self.log_in_status_bar == "user":
                 path = user_friendly(path)

--- a/libs/input_for_path.py
+++ b/libs/input_for_path.py
@@ -33,6 +33,7 @@ class InputForPath(object):
     def __init__(
         self,
         caption,
+        type,
         initial_text,
         on_done,
         on_change,
@@ -53,6 +54,7 @@ class InputForPath(object):
         self.user_on_change = on_change
         self.user_on_cancel = on_cancel
         self.caption = caption
+        self.type = type
         self.initial_text = initial_text
         self.log_template = log_template
         self.browser_action = browser_action
@@ -301,7 +303,7 @@ class InputForPath(object):
             self.browser.path = computer_path
             return self.browsing_on_done()
         else:
-            self.user_on_done(computer_path, input_path)
+            self.user_on_done(computer_path, input_path, self.type)
 
     def input_on_cancel(self):
         active_view = self.window.active_view()

--- a/libs/sublimefunctions.py
+++ b/libs/sublimefunctions.py
@@ -160,6 +160,13 @@ def to_snake_case(camelCaseString):
     return snake
 
 
+def toCamelCase(snake_str):
+    components = snake_str.split('_')
+    # We capitalize the first letter of each component except the first one
+    # with the 'title' method and join them together.
+    return components[0] + ''.join(x.title() for x in components[1:])
+
+
 def StdClass(name="Unknown"):
     # add the str() function because of the unicode in Python 2
     return type(str(name).title(), (), {})


### PR DESCRIPTION
The `auto namespace discovery` will look inside your `composer.json` and tries to find the correct namespace with `autoload->psr-4`. Even if you are wanna make a PHP file inside a tests directory it will look inside the your `autoload-dev->psr-4` .

I have also added support for making folders when the path begins with a `/` and is not ending with one Or when a path is not beginning and ending with a `/` and it has not an extension at the end it will also work.

<img width="290" alt="Screenshot 2022-04-05 at 13 49 13" src="https://user-images.githubusercontent.com/62463826/161747528-f5fa4529-7f65-4d70-b931-005cb1332e44.png">
<img width="290" alt="Screenshot 2022-04-05 at 16 03 00" src="https://user-images.githubusercontent.com/62463826/161771674-5497f9f0-3cd1-40fc-b094-df74d8892d59.png">
<img width="401" alt="Screenshot 2022-04-05 at 16 02 50" src="https://user-images.githubusercontent.com/62463826/161771754-642cdc12-4dcc-415e-b0bc-d8663269c7b0.png">

