### PR TITLE
Hide "Open Folder..." command from Default package

### DIFF
--- a/prevent_default.py
+++ b/prevent_default.py
@@ -1,5 +1,5 @@
 import sublime_plugin
-from Default.side_bar import RenamePathCommand
+from Default.side_bar import RenamePathCommand as DefaultRenamePathCommand
 
 
 class NewFileAtCommand(sublime_plugin.WindowCommand):
@@ -34,12 +34,20 @@ class DeleteFolderCommand(sublime_plugin.WindowCommand):
         return False
 
 
-class RenamePathCommand(RenamePathCommand):
+class RenamePathCommand(DefaultRenamePathCommand):
     def is_visible(self):
         return False
 
 
 class FindInFolderCommand(sublime_plugin.WindowCommand):
+    def is_visible(self):
+        return False
+
+    def is_enabled(self):
+        return False
+
+
+class OpenFolderCommand(sublime_plugin.WindowCommand):
     def is_visible(self):
         return False
 


### PR DESCRIPTION
FileManager didn't hide the built-in `OpenFolderCommand`(`Open Folder...`) even though it provides its own equivalent (`Open in Finder`).

![Screenshot 2023-02-09 at 22 14 06](https://user-images.githubusercontent.com/153197/217940844-74a2e798-d287-4878-bd5a-a6b1003854f1.png)

It did hide the built-in `OpenContainingFolderCommand` already so I'm guessing that this was just an omission.

The small change in imports is due to pyright type-checker reporting that class can't inherit itself. It might have worked in practice but I think this is more explicit and clear with my change.